### PR TITLE
La til ANSI som støttet tegnsett.

### DIFF
--- a/src/main/java/no/jsosi/Tegnsett.java
+++ b/src/main/java/no/jsosi/Tegnsett.java
@@ -13,7 +13,7 @@ public class Tegnsett {
         }
 
         // fake this one for now. sorry
-        if (characterSet.equals("ISO-8859-10")) {
+        if (characterSet.equals("ISO-8859-10") || characterSet.equalsIgnoreCase("ANSI")) {
             characterSet = "ISO-8859-1";
         }
         


### PR DESCRIPTION
En del filer fra forskjellige kilder kommer med tegnsett satt til "ANSI", som i følge standarden er støttet og er 100% overlappende med 8859-1. Det var ikke støtte for dette i koden, så parsinga stoppet opp, og jeg la det derfor til :)
